### PR TITLE
Fix spec and run it on github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+on:
+  pull_request:
+  push:
+    branches:
+      # - "master"
+      - "*" # for test
+jobs:
+  test:
+    strategy:
+      matrix:
+        ruby: ['2.5', '2.6', '2.7']
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: SAMPLE_AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY: SAMPLE_AWS_SECRET_ACCESS_KEY
+      AWS_REGION: ap-northeast-1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rspec
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local
+        ports:
+          - "8000:8000"
+        env:
+          AWS_ACCESS_KEY_ID: SAMPLE_AWS_ACCESS_KEY_ID
+          AWS_SECRET_ACCESS_KEY: SAMPLE_AWS_SECRET_ACCESS_KEY
+          AWS_REGION: ap-northeast-1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      # - "master"
-      - "*" # for test
+      - "master"
 jobs:
   test:
     strategy:

--- a/dyna.gemspec
+++ b/dyna.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diffy', '~> 3.1'
   spec.add_dependency 'hashie', '~> 3.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.4'

--- a/lib/dyna/client.rb
+++ b/lib/dyna/client.rb
@@ -8,7 +8,7 @@ module Dyna
       @options_hash = options
       if @options.use_local
         @options.ddb = Aws::DynamoDB::Client.new(
-          endpoint: @options.dynamo_endpoint || 'http://127.0.0.1:8000',
+          endpoint: @options.dynamo_endpoint || 'http://localhost:8000',
           region: @options.region || 'ap-northeast-1',
           access_key_id: @options.access_key_id || 'dummy',
           secret_access_key: @options.secret_access_key || 'dummy',

--- a/lib/dyna/client.rb
+++ b/lib/dyna/client.rb
@@ -9,9 +9,6 @@ module Dyna
       if @options.use_local
         @options.ddb = Aws::DynamoDB::Client.new(
           endpoint: @options.dynamo_endpoint || 'http://localhost:8000',
-          region: @options.region || 'ap-northeast-1',
-          access_key_id: @options.access_key_id || 'dummy',
-          secret_access_key: @options.secret_access_key || 'dummy',
         )
       else
         @options.ddb = Aws::DynamoDB::Client.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ def cleanup_dynamo
   client = Aws::DynamoDB::Client.new
   client.list_tables.table_names.each do |table_name|
     wait_until_table_is_active(client, table_name)
-    wait_until_global_index_is_active(client, table_name, '')
+    wait_until_global_index_is_active(client, table_name)
     client.delete_table(table_name: table_name)
     wait_until_table_is_active(client, table_name)
   end

--- a/spec/update_table_spec.rb
+++ b/spec/update_table_spec.rb
@@ -88,7 +88,7 @@ EOS
       end
 
       wait_until_table_is_active(@ddb_client, table_name)
-      wait_until_global_index_is_active(@ddb_client, table_name, 'GlobalIndexName')
+      wait_until_global_index_is_active(@ddb_client, table_name)
 
       desc = describe_table(@ddb_client, table_name)
 


### PR DESCRIPTION
## motivation
This gem has specs, but it didn't execute anywhere.

I know a repository that uses this gem, that specified ruby 2.5. Ruby 2.5 is end-of-life already. So I want to upgrade it.

But this gem was not tested ruby 2.5 to 2.6 or higher version. (there is no 
 evidence to runnable ruby 2.6 or higher because not tested on any CI services)

Then I tried to run specs on my local machine. So I found the spec is broken.

This pull req does fix broken specs and enable CI on github actions.

## changes
- run CI for ruby 2.5, 2.6, and 2.7 on github actions (when pull request opened or merged to master branch)
- fix wrong arguments for helper methods in `spec_helper`
- remove hard coded aws config envs in `lib/dyna/client.rb` (it makes CI harder)

https://github.com/unasuke/dyna/actions/runs/2528249479
![image](https://user-images.githubusercontent.com/4487291/174583322-a2564ec6-5235-4e68-b74b-58deba2c2a04.png)
